### PR TITLE
Persist frontend state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -98,9 +98,24 @@ const App = () => {
   // 
   //const [logData, setLogData] = useState([]);
   useEffect(() => {
+    const sessionLogin = JSON.parse(window.sessionStorage.getItem('LOGIN'));
+    if (sessionLogin !== null) setLogin(sessionLogin);
+
+    const sessionFunctionData = JSON.parse(window.sessionStorage.getItem('FUNCTION_DATA'));
+    if (sessionFunctionData !== null) setFunctionData(sessionFunctionData);
+  }, [])
+  
+  useEffect(() => {
+    window.sessionStorage.setItem('LOGIN', JSON.stringify(login));
     if(login){
-      getFuncs(setFunctionData);
+      if (Object.keys(functionData).length === 0) {
+        getFuncs(setFunctionData);
+      }
   }}, [login]);
+
+  useEffect(() => {
+    window.sessionStorage.setItem('FUNCTION_DATA', JSON.stringify(functionData));
+  }, [functionData]);
 
   // useEffect(() => {
   //   console.log(functionData)

--- a/src/containers/Messages.jsx
+++ b/src/containers/Messages.jsx
@@ -1,9 +1,4 @@
 import React, {useState} from 'react';
-<<<<<<< HEAD
-// import LogsHeader from '../components/LogsHeader';
-// import MessageRow from '../components/MessageRow';
-=======
->>>>>>> dev
 import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, InputLabel, MenuItem, FormControl, Select, Button } from '@mui/material';
 import { dateTime } from '../utils/conversions';
 import FilterSelection from './FilterSelection';

--- a/src/containers/Messages.jsx
+++ b/src/containers/Messages.jsx
@@ -1,6 +1,6 @@
 import React, {useState} from 'react';
-import LogsHeader from '../components/LogsHeader';
-import MessageRow from '../components/MessageRow';
+// import LogsHeader from '../components/LogsHeader';
+// import MessageRow from '../components/MessageRow';
 import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper, InputLabel, MenuItem, FormControl, Select, Button } from '@mui/material';
 import { dateTime } from '../utils/conversions';
 import FilterSelection from './FilterSelection';

--- a/src/containers/MetricsPage.jsx
+++ b/src/containers/MetricsPage.jsx
@@ -37,6 +37,22 @@ const MetricsPage = (props) => {
     period: null,
     startTime: null
   });
+
+  useEffect(() => {
+    const sessionDisplayProps = JSON.parse(window.sessionStorage.getItem('DISPLAY_PROPS'));
+    if (sessionDisplayProps !== null) setDisplayProps(sessionDisplayProps);
+
+    const sessionDataLoaded = JSON.parse(window.sessionStorage.getItem('DATA_LOADED'));
+    if (sessionDataLoaded !== null) setDataLoaded(sessionDataLoaded);
+  }, []);
+
+  useEffect(() => {
+    window.sessionStorage.setItem('DATA_LOADED', JSON.stringify(dataLoaded));
+  }, [dataLoaded])
+  
+  useEffect(() => {
+    window.sessionStorage.setItem('DISPLAY_PROPS', JSON.stringify(displayProps));
+  }, [displayProps])
   
   const navigate = useNavigate();
   const handleLogClick = useCallback(() => navigate('/logs', {replace: true}), [navigate]);


### PR DESCRIPTION
- Persist parts of front end state over the life of a tab session to allow for page reloading without losing views or data